### PR TITLE
Add tests for study session functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Node tests
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+        mongodb-version: [4.2]
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.3.0
+        with:
+          mongodb-version: ${{ matrix.mongodb-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+        env:
+          DATABASE_URI: mongodb://localhost:27017

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,25 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "args": [
+                "--timeout",
+                "999999",
+                "--colors",
+                "${workspaceFolder}/test",
+                "-r",
+                "esm",
+                "--recursive"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "name": "Mocha Tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "pwa-node"
+        },
+        {
             "command": "npm run dev",
             "name": "Start bot in debug mode",
             "request": "launch",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "forever:start": "forever start lib/index.js",
     "forever:stop": "forever stop lib/index.js || exit 0",
     "prestart": "npm run build && npm run forever:stop",
-    "start": "npm run forever:start"
+    "start": "npm run forever:start",
+    "test": "mocha 'test' -r esm --recursive --exit"
   },
   "author": "Chris McDonald",
   "license": "ISC",
@@ -25,6 +26,9 @@
     "@babel/node": "^7.12.10",
     "@babel/plugin-proposal-throw-expressions": "^7.12.1",
     "@babel/preset-env": "^7.12.11",
+    "chai": "^4.3.0",
+    "esm": "^3.2.25",
+    "mocha": "^8.3.0",
     "nodemon": "^2.0.7"
   }
 }

--- a/src/scripts/activities/study-session.js
+++ b/src/scripts/activities/study-session.js
@@ -54,7 +54,7 @@ function createStudySession(message) {
 	const studySession = getStudySession(message);
 	// Check if studySession is a promise
 	if (typeof studySession.then === "function") return null;
-	StudySession.create(studySession)
+	return StudySession.create(studySession)
 		.then(() => {
 			replySuccess(message, STUDY_SESSION.CREATE.SUCCESS(studySession));
 			react(message, null, ["⭐", "❌"]);
@@ -63,7 +63,7 @@ function createStudySession(message) {
 }
 
 function getUpcomingStudySessions(message) {
-	StudySession.find({ startDate: { $gt: new Date() } }, null, { sort: "startDate" }, (error, studySessions) => {
+	return StudySession.find({ startDate: { $gt: new Date() } }, null, { sort: "startDate" }, (error, studySessions) => {
 		if (error) return replyError(message, STUDY_SESSION.UPCOMING.ERROR(error));
 		if (studySessions.length === 0) return replyError(message, STUDY_SESSION.UPCOMING.NOT_FOUND);
 		return replySuccess(message, STUDY_SESSION.UPCOMING.SUCCESS(studySessions));
@@ -71,19 +71,19 @@ function getUpcomingStudySessions(message) {
 }
 
 function subscribeStudySession(message, user) {
-	StudySession.findOneAndUpdate({ "message.id": message.id }, { $push: { subscribersId: user.id } })
+	return StudySession.findOneAndUpdate({ "message.id": message.id }, { $push: { subscribersId: user.id } })
 		.then(() => sendDirectMessage(user, STUDY_SESSION.SUBSCRIBE.SUCCESS(message.author, user)))
 		.catch((error) => sendDirectMessage(user, STUDY_SESSION.SUBSCRIBE.ERROR(user, error)));
 }
 
 function unsubscribeStudySession(message, user) {
-	StudySession.findOneAndUpdate({ "message.id": message.id }, { $pull: { subscribersId: user.id } })
+	return StudySession.findOneAndUpdate({ "message.id": message.id }, { $pull: { subscribersId: user.id } })
 		.then(() => sendDirectMessage(user, STUDY_SESSION.UNSUBSCRIBE.SUCCESS(message.author, user)))
 		.catch((error) => sendDirectMessage(user, STUDY_SESSION.UNSUBSCRIBE.ERROR(user, error)));
 }
 
 function notifySubscribers(client, studySession) {
-	studySession.subscribersId.map((subscriberId) => {
+	return studySession.subscribersId.map((subscriberId) => {
 		return client.users
 			.fetch(subscriberId)
 			.then((subscriber) => {
@@ -95,7 +95,7 @@ function notifySubscribers(client, studySession) {
 
 function cancelConfirmationStudySession(message, user) {
 	if (message.author.id !== user.id) return replyError(message, STUDY_SESSION.CANCEL.UNAUTHORIZED);
-	replySurvey(message, STUDY_SESSION.CANCEL.CONFIRMATION(user), ["✅", "❌"], 60000)
+	return replySurvey(message, STUDY_SESSION.CANCEL.CONFIRMATION(user), ["✅", "❌"], 60000)
 		.then((result) => {
 			switch (result) {
 				case "✅":

--- a/test/scripts/activities/study-session.test.js
+++ b/test/scripts/activities/study-session.test.js
@@ -1,0 +1,333 @@
+require('dotenv').config();
+const { Client, Channel, User, Message, Reaction } = require('./../../utils/discord-dummy');
+const chai = require('chai');
+const expect = chai.expect;
+const mongoose = require('mongoose');
+const StudySessionSchema = require('./../../../src/models/index');
+const StudySessionModel = mongoose.models.StudySession;
+const {
+    createStudySession,
+    getUpcomingStudySessions,
+    subscribeStudySession,
+    unsubscribeStudySession,
+    cancelConfirmationStudySession,
+    notifySubscribers
+} = require('./../../../src/scripts/activities/study-session');
+
+describe('When working with study sessions', function () {
+    before(function (done) {
+        mongoose.connect(process.env.DATABASE_URI, {
+            useNewUrlParser: true,
+            useCreateIndex: true,
+            useUnifiedTopology: true,
+            useFindAndModify: false
+        });
+
+        const database = mongoose.connection;
+        database.on('error', function () {
+            console.error('Failed to connect to database');
+        });
+        database.once('open', function () {
+            done();
+        });
+    });
+
+    describe('When creating a session using the createStudySession function', function () {
+        it('Should be able to create a study session', async function () {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            let message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+
+            await createStudySession(message);
+            const queryResult = await StudySessionModel.find();
+            expect(queryResult).to.be.an('array').with.lengthOf(1);
+        });
+
+        it('Should be able to create a study session with correct author information', async function () {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            let message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+
+            await createStudySession(message);
+            const queryResult = await StudySessionModel.find();
+            const foundStudySession = queryResult[0];
+            expect(foundStudySession.get('author').username).to.eql(user.username);
+            expect(foundStudySession.get('author').id).to.eql(user.id);
+        });
+
+        it('Should be able to create a study session with correct message information', async function () {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            let message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+
+            await createStudySession(message);
+            const queryResult = await StudySessionModel.find();
+            const foundStudySession = queryResult[0];
+            expect(foundStudySession.get('message').text).to.eql(message.content.replace('!study', ''));
+            expect(foundStudySession.get('message').id).to.eql(message.id);
+            expect(foundStudySession.get('message').link).to.eql(message.url);
+        });
+
+        it('Should be able to create a study session with correct start date', async function () {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            let message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+
+            await createStudySession(message);
+            const queryResult = await StudySessionModel.find();
+            const foundStudySession = queryResult[0];
+            expect(foundStudySession.get('startDate').getFullYear()).to.eql(validStudySessionDate.getFullYear());
+            expect(foundStudySession.get('startDate').getMonth()).to.eql(validStudySessionDate.getMonth());
+            expect(foundStudySession.get('startDate').getDate()).to.eql(validStudySessionDate.getDate());
+            expect(foundStudySession.get('startDate').getHours()).to.eql(validStudySessionDate.getHours());
+            expect(foundStudySession.get('startDate').getMinutes()).to.eql(validStudySessionDate.getMinutes());
+        });
+    });
+
+    describe('When retrieving sessions using the getUpcomingStudySessions function', function () {
+        it('Should send a message into the command message\'s channel', function (done) {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            let message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+            // Unfortunately this has to be written in an awkward callback way instead of awaiting so that we can use a setTimeout, i'm sorry
+            createStudySession(message).then(function () {
+                message = new Message(channel, user, '!upcoming', 'messageUrl');
+                channel.send(message);
+                getUpcomingStudySessions(message).then(function () {
+                    setTimeout(() => {
+                        expect(channel.messages).to.be.an('array').with.lengthOf(4);
+                        expect(channel.messages[3].content).to.include('Here are the upcoming study sessions');
+                        expect(channel.messages[3].embed.fields).to.be.an('array').with.lengthOf(1);
+                        done();
+                    }, 0);
+                });
+            });
+
+        });
+
+        it('Should send a message into the command message\'s channel with correct embed information', function (done) {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            let message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+            // Unfortunately this has to be written in an awkward callback way instead of awaiting so that we can use a setTimeout, i'm sorry
+            createStudySession(message).then(function () {
+                message = new Message(channel, user, '!upcoming', 'messageUrl');
+                channel.send(message);
+                getUpcomingStudySessions(message).then(function () {
+                    setTimeout(() => {
+                        expect(channel.messages[3].embed.fields[0].name).to.eql(`${user.username}'s study session`);
+                        expect(channel.messages[3].embed.fields[0].value).to.include(studySessionContent);
+                        done();
+                    }, 0);
+                });
+            });
+
+        });
+    });
+
+    describe('When subscribing to a session using the subscribeStudySession function', function () {
+        it('Should send a direct message to a user who subscribes to a study session', async function () {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            const message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+            await createStudySession(message);
+            await subscribeStudySession(message, user);
+
+            expect(user.directMessages).to.be.an('array').with.lengthOf(1);
+        });
+
+        it('Should send a direct message to a user who subscribes to a study session with correct content', async function () {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            const message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+            await createStudySession(message);
+            await subscribeStudySession(message, user);
+
+            expect(user.directMessages[0].content).to.eql(`👋 Hey ${user.username}, you successfully registered to <@${user.id}> study session! See you soon!`);
+        });
+    });
+
+    describe('When unsubscribing to a session using the unsubscribeStudySession function', function () {
+        it('Should send a direct message to a user who unsubscribes to a study session', async function () {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            const message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+            await createStudySession(message);
+            await subscribeStudySession(message, user);
+            await unsubscribeStudySession(message, user);
+
+            expect(user.directMessages).to.be.an('array').with.lengthOf(2);
+        });
+
+        it('Should send a direct message to a user who unsubscribes to a study session with correct content', async function () {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            const message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+            await createStudySession(message);
+            await subscribeStudySession(message, user);
+            await unsubscribeStudySession(message, user);
+
+            expect(user.directMessages[1].content).to.eql(`😢 Oh dear ${user.username}, you unsubscribed to <@${user.id}> study session... Maybe next time!`);
+        });
+    });
+
+    describe('When notifying subscribers using the notifySubscribers function', function () {
+        it('Should send a direct message to a user who has subscribed to a session', async function () {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            const message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+            await createStudySession(message);
+            await subscribeStudySession(message, user);
+
+            const client = new Client();
+            client.addUser(user);
+            const queryResult = await StudySessionModel.find();
+            const foundStudySession = queryResult[0];
+            await notifySubscribers(client, foundStudySession);
+
+            expect(user.directMessages).to.be.an('array').with.lengthOf(2);
+        });
+
+        it('Should send a direct message to a user who has subscribed to a study session with correct content', async function () {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            const message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+            await createStudySession(message);
+            await subscribeStudySession(message, user);
+
+            const client = new Client();
+            client.addUser(user);
+            const queryResult = await StudySessionModel.find();
+            const foundStudySession = queryResult[0];
+            await notifySubscribers(client, foundStudySession);
+
+            expect(user.directMessages[1].content).to.include(`👋 How is your day going, ${user.username}? Thank you for waiting, <@${user.id}>'s study session is starting soon! See you on the Korean Study Group server`);
+        });
+    });
+
+    describe('When cancelling a session using the cancelConfirmationStudySession function', function () {
+        it('Should respond with a confirmation survey', async function () {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            const message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+            await createStudySession(message);
+            cancelConfirmationStudySession(message, user);
+
+            expect(channel.messages).to.be.an('array').with.lengthOf(3);
+        });
+
+        it('Should send a reply when confirming cancellation by applying a ✅ reaction to the survey', function (done) {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            const message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+            // Unfortunately this has to be written in an awkward callback way instead of awaiting so that we can use a setTimeout, i'm sorry
+            createStudySession(message).then(function () {
+                cancelConfirmationStudySession(message, user);
+                channel.messages[2].react(new Reaction('✅', user));
+                setTimeout(() => {
+                    expect(channel.messages).to.be.an('array').with.lengthOf(4);
+                    done();
+                }, 300);
+            });
+        });
+
+        it('Should have a message with correct contents when a cancellation is confirmed by applying a ✅ reaction to the survey', function (done) {
+            const user = new User('username');
+            const channel = new Channel();
+            const currentDateTime = new Date();
+            const validStudySessionDate = new Date(new Date().setFullYear(currentDateTime.getFullYear() + 1));
+            const formattedStudySessionDateTime = validStudySessionDate.toISOString().substr(0, 16).replace("T", " ").split('-').join('/');
+            const studySessionContent = 'This is a study session';
+            const message = new Message(channel, user, `!study ${studySessionContent} ${formattedStudySessionDateTime} 1 hour`, 'messageUrl');
+            channel.send(message);
+            // Unfortunately this has to be written in an awkward callback way instead of awaiting so that we can use a setTimeout, i'm sorry
+            createStudySession(message).then(function () {
+                cancelConfirmationStudySession(message, user);
+                channel.messages[2].react(new Reaction('✅', user));
+                setTimeout(() => {
+                    expect(channel.messages[3].content).to.eql(`😉 Roger! Study session has been cancelled. Looking forward to see you again, <@${user.id}>!`);
+                    done();
+                }, 300);
+            });
+        });
+    });
+
+    afterEach(async function () {
+        await StudySessionModel.deleteMany();
+    })
+
+    after(async function () {
+        await mongoose.connection.db.dropDatabase();
+        await mongoose.connection.close();
+    });
+});

--- a/test/utils/discord-dummy.js
+++ b/test/utils/discord-dummy.js
@@ -1,0 +1,133 @@
+class Users {
+    constructor() {
+        this.users = [];
+    }
+
+    addUser(user) {
+        this.users.push(user);
+    }
+
+    fetch(userId) {
+        const user = this.users.find(function (user) {
+            return user.id === userId;
+        });
+        return new Promise(function (callback) {
+            callback(user);
+        });
+    }
+}
+
+class Client {
+    constructor() {
+        this.id = generateId();
+        this.users = new Users();
+    }
+
+    addUser(user) {
+        this.users.addUser(user);
+    }
+}
+
+class User {
+    constructor(username) {
+        this.username = username;
+        this.avatarUrl = 'avatarUrl';
+
+        this.id = generateId();
+        this.directMessages = [];
+    }
+
+    displayAvatarURL() {
+        return this.avatarUrl;
+    }
+
+    send(message) {
+        this.directMessages.push(message);
+        return new Promise(function (callback) {
+            return callback(message);
+        });
+    }
+}
+
+class Channel {
+    constructor() {
+        this.id = generateId();
+        this.messages = [];
+    }
+
+    getLastMessage() {
+        return this.messages[this.messages.length - 1];
+    }
+
+    send(message) {
+        if (Object.keys(message).length === 1 && typeof message.content === 'string') {
+            message = new Message(this, '', message.content, '');
+        }
+        this.messages.push(message);
+        return new Promise(function (callback) {
+            return callback(message);
+        });
+    }
+}
+
+class Message {
+    constructor(channel, author, content, url) {
+        this.channel = channel;
+        this.author = author;
+        this.content = content;
+        this.url = url;
+
+        this.id = generateId();
+        this.reactions = [];
+    }
+
+    edit(content) {
+        this.content = content;
+        return new Promise(function (callback) {
+            return callback(this);
+        });
+    }
+
+    react(reaction) {
+        if (typeof reactions === 'string') {
+            reaction = new Reaction(reaction);
+        }
+        this.reactions.push(reaction);
+    }
+
+    awaitReactions(filterCallback) {
+        let reactions = this.reactions.filter(function (reaction) {
+            if (typeof reaction === 'string') {
+                return false;
+            }
+            return filterCallback(reaction, reaction.user);
+        });
+        return new Promise(function (callback) {
+            return callback(new MinimalCollectionWrapper(reactions));
+        });
+    }
+}
+
+class Reaction {
+    constructor(reaction, user) {
+        this.emoji = {};
+        this.emoji.name = reaction;
+        this.user = user;
+    }
+}
+
+class MinimalCollectionWrapper {
+    constructor(items) {
+        this.items = items;
+    }
+
+    first() {
+        return this.items[0];
+    }
+}
+
+function generateId() {
+    return Math.random().toString(36).substring(2, 15);
+}
+
+module.exports = { Client, Channel, User, Message, Reaction };


### PR DESCRIPTION
- Added tests for study session happy paths
  - Added mocha, chai, esm dev dependencies for tests
    - mocha as a test framework
      - Added mocha config to launch.json for debugging tests
    - chai as an assertion library to set test cases
    - esm as a module loader for mocha compatibility
- Added simple discord dummy class for tests
- Added test script, `npm test`
- Added workflow file to run tests in CI
- Modified functions in study-session.js to return their Promises