### PR TITLE
Fix a few issues with user commands not restarting game correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,14 +94,14 @@ client.on("message", (message) => {
 
 	// --- EXERCISES ---
 	switch (true) {
+		case gameIsRunning():
+			gameListener(message);
+			break;
 		case shouldStartGame(message, client):
 			startGame(message);
 			break;
 		case text.includes(process.env.CLIENT_ID) && text.includes("stop"):
 			endGame(message, true);
-			break;
-		case gameIsRunning():
-			gameListener(message);
 			break;
 	}
 

--- a/src/scripts/activities/games.js
+++ b/src/scripts/activities/games.js
@@ -74,9 +74,12 @@ function containsCommandForGame(messageContent, gameName) {
 	if (messageContent.includes(process.env.CLIENT_ID) && messageContent.includes(GAMES[gameName].commands.long)) {
 		return true;
 	}
-	if (messageContent.endsWith(GAMES[gameName].commands.short)) {
+	const shortCommand = GAMES[gameName].commands?.short;
+	const hangulCommand = GAMES[gameName].commands?.hangul;
+	if (messageContent.endsWith(shortCommand) || messageContent.endsWith(hangulCommand)) {
 		return true;
 	}
+	
 	return false;
 }
 

--- a/src/scripts/activities/games.js
+++ b/src/scripts/activities/games.js
@@ -71,16 +71,17 @@ function sendWrongChannelMessage(client, message) {
 }
 
 function containsCommandForGame(messageContent, gameName) {
-	if (messageContent.includes(process.env.CLIENT_ID) && messageContent.includes(GAMES[gameName].commands.long)) {
-		return true;
+	const commands = [GAMES[gameName].commands.short, GAMES[gameName].commands.long];
+	if (GAMES[gameName].commands.hangul) {
+		commands.push(GAMES[gameName].commands.short)
 	}
-	const shortCommand = GAMES[gameName].commands?.short;
-	const hangulCommand = GAMES[gameName].commands?.hangul;
-	if (messageContent.endsWith(shortCommand) || messageContent.endsWith(hangulCommand)) {
-		return true;
-	}
-	
-	return false;
+	const commandPrefixRegex = `\!`;
+	const botMentionRegex = `\<\@\!?${process.env.CLIENT_ID}\>\s?${commandPrefixRegex}?`;
+	const gameStartCommandRegex = `${commands.join('|')}`;
+	const commandRegex = new RegExp(
+		`^((${botMentionRegex})|${commandPrefixRegex})(${gameStartCommandRegex})\b`
+	);
+	return commandRegex.test(messageContent);
 }
 
 function startGame(message) {

--- a/src/scripts/activities/typing-game.js
+++ b/src/scripts/activities/typing-game.js
@@ -103,6 +103,7 @@ function sendChallenge(message, word, definition) {
 }
 
 function handleMessageDuringGame(message) {
+    if (userRestartedGame(message)) return;
     try {
         if (message.content === answers[roundCount].word) {
             roundCount = roundCount + 1;
@@ -153,12 +154,23 @@ function handleMessageDuringGame(message) {
 }
 
 function endGame() {
-    resetGameVariables();
     clearTimeout(gameTimeout);
+    resetGameVariables();
 }
 
 function gameIsInProgress() {
     return gameInProgress;
+}
+
+function userRestartedGame(message) {
+    Object.keys(commands).forEach((command) => {
+        if (message.content.includes(commands[command])) {
+            endGame();
+            startGame(message);
+            return true;
+        }
+    })
+    return false;
 }
 
 module.exports = { gameName, commands, setUp, startGame, handleMessageDuringGame, endGame, gameIsInProgress };


### PR DESCRIPTION
I loved the refactor you started and decided to do some work on it as well.
Here's what's in this fix:

* **GAMES.JS / TYPING-GAME.JS** : 
  * Included a check for hangul commands when starting the typing game 
  * Added a function that checks if a user is trying to restart the game
    * This is to deal with users leaving a game unfinished and another user entering the channel and trying to start a new one sometime later.
  * Reordered the `clearTimeout()` and `resetGameVariables()` function calls in the `endGame()` function in typing-game.js
    * `resetGameVariables()` reset the `gameTimeout` to null, so `clearTimeout()` wasn't able to clear it previously.  

* **INDEX.JS** : 
  * Moved `gameIsRunning()` higher in the switch to allow `gameListener()` to check for when users try to restart the game.

Edit: _I merged the dev branch into your fork before I started working on it, so that's where the lines that look like additional changes to study sessions come from._